### PR TITLE
Dependabot: actually switch to new 'uv' ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,7 +14,7 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: monthly


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yaml` file. The change updates the `package-ecosystem` from `pip` to `uv` for dependency updates.

* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cL17-R17): Changed `package-ecosystem` from `pip` to `uv` for dependency updates.